### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
 language: node_js
 node_js:
-  - 8.4.0
+  - 8.5.0
 sudo: false
 branches:
   only:

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -12,6 +12,7 @@
 [![Dependency Status](https://david-dm.org/arlac77/rtsp-archive.svg)](https://david-dm.org/arlac77/rtsp-archive)
 [![devDependency Status](https://david-dm.org/arlac77/rtsp-archive/dev-status.svg)](https://david-dm.org/arlac77/rtsp-archive#info=devDependencies)
 [![docs](http://inch-ci.org/github/arlac77/rtsp-archive.svg?branch=master)](http://inch-ci.org/github/arlac77/rtsp-archive)
+[![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![downloads](http://img.shields.io/npm/dm/rtsp-archive.svg?style=flat-square)](https://npmjs.org/package/rtsp-archive)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "posttest": "npm run prepare && markdown-doctest",
     "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "prepare": "rollup -c -- src/rtsp-archive.js && chmod +x bin/rtsp-archive"
+    "prepare": "rollup -c && chmod +x bin/rtsp-archive"
   },
   "repository": {
     "type": "git",
@@ -38,18 +38,17 @@
   },
   "devDependencies": {
     "ava": "^0.22.0",
-    "babel-preset-stage-3": "^6.24.1",
     "execa": "^0.8.0",
     "jsdoc-babel": "^0.3.0",
     "jsdoc-to-markdown": "^3.0.0",
     "markdown-doctest": "^0.9.1",
-    "nyc": "^11.1.0",
-    "rollup": "^0.47.6",
+    "nyc": "^11.2.1",
+    "rollup": "^0.50.0",
     "rollup-plugin-babel": "^3.0.2",
-    "rollup-plugin-commonjs": "^8.1.0",
+    "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-multi-entry": "^2.0.1",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "semantic-release": "^8.0.0",
+    "semantic-release": "^8.0.3",
     "xo": "^0.19.0"
   },
   "contributors": [
@@ -60,7 +59,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=8.4.0"
+    "node": ">=8.5.0"
   },
   "ava": {
     "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,12 @@ import commonjs from 'rollup-plugin-commonjs';
 import pkg from './package.json';
 
 export default {
-  banner: '#!/usr/bin/env node',
-  targets: [{
-    dest: pkg.bin['rtsp-archive'],
-    format: 'cjs'
-  }],
+  output: {
+    file: pkg.bin['rtsp-archive'],
+    format: 'cjs',
+    banner: '#!/usr/bin/env node'
+  },
   plugins: [nodeResolve(), commonjs()],
-  external: ['config-expander']
+  external: ['config-expander'],
+  input: pkg.module
 };

--- a/tests/rollup.config.js
+++ b/tests/rollup.config.js
@@ -2,8 +2,9 @@ import babel from 'rollup-plugin-babel';
 import multiEntry from 'rollup-plugin-multi-entry';
 
 export default {
-  entry: 'tests/**/*-test.js',
+  input: 'tests/**/*-test.js',
   external: ['ava'],
+
   plugins: [
     babel({
       babelrc: false,
@@ -12,7 +13,10 @@ export default {
     }),
     multiEntry()
   ],
-  format: 'cjs',
-  dest: 'build/test-bundle.js',
-  sourceMap: true
+
+  output: {
+    file: 'build/test-bundle.js',
+    format: 'cjs',
+    sourcemap: true
+  }
 };


### PR DESCRIPTION
rollup.config.js
---
- chore(rollup): update from template

tests/rollup.config.js
---
- chore(rollup): update from template

package.json
---
- chore(scripts): update prepare@rollup -c from template
- chore(devDependencies): update nyc@^11.2.1 from template
- chore(devDependencies): update rollup@^0.50.0 from template
- chore(devDependencies): update rollup-plugin-commonjs@^8.2.1 from template
- chore(devDependencies): update semantic-release@^8.0.3 from template
- chore(engines): update node@>=8.5.0 from template

doc/README.hbs
---
- docs(README): update from template

.travis.yml
---
- chore(travis): merge from template .travis.yml
